### PR TITLE
Bump Elasticsearch, Kibana, and Logstash charms

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,13 +1,13 @@
 series: trusty
 services:
   elasticsearch:
-    charm: "cs:trusty/elasticsearch-14"
+    charm: "cs:trusty/elasticsearch-18"
     num_units: 2
     annotations:
       "gui-x": "1374"
       "gui-y": "569"
   logstash:
-    charm: "cs:~containers/trusty/logstash-3"
+    charm: "cs:trusty/logstash-0"
     num_units: 1
     constraints: "mem=2G"
     annotations:
@@ -20,7 +20,7 @@ services:
       "gui-y": "469"
   kibana:
     expose: true
-    charm: "cs:trusty/kibana-10"
+    charm: "cs:trusty/kibana-14"
     num_units: 1
     annotations:
       "gui-x": "1626"


### PR DESCRIPTION
Bumps ES to 18, Kibana to 14, And Logstash to promulgated versions.
