### PR TITLE
bump charms to latest revs (ELK stack is now v6); include constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ custom dashboards that help you share insights from your data far and wide.
 This bundle is a 4 node cluster designed to scale out. Built around Elastic
 components, it contains:
 
-- 1 Logstash unit (minimum mem=2GB)
-- 2 Elasticsearch units
-- 1 Kibana unit
+- 1 Logstash unit (minimum mem=3GB)
+- 2 Elasticsearch units (minimum mem=7GB)
+- 1 Kibana unit (minimum mem=3GB)
 
 ## Usage
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,26 +1,31 @@
 series: xenial
 services:
   elasticsearch:
-    charm: "cs:xenial/elasticsearch-25"
+    charm: "cs:bionic/elasticsearch-39"
+    series: bionic
+    constraints: mem=7G root-disk=16G
     num_units: 2
+    options:
+      apt-repository: "deb https://artifacts.elastic.co/packages/6.x/apt stable main"
     annotations:
       "gui-x": "1374"
       "gui-y": "569"
   logstash:
-    charm: "cs:xenial/logstash-3"
+    charm: "cs:xenial/logstash-5"
     num_units: 1
-    constraints: "mem=2G"
+    constraints: "mem=3G"
     annotations:
       "gui-x": "1086"
       "gui-y": "569"
   openjdk:
-    charm: "cs:xenial/openjdk-5"
+    charm: "cs:xenial/openjdk-6"
     annotations:
       "gui-x": "942"
       "gui-y": "469"
   kibana:
     expose: true
-    charm: "cs:xenial/kibana-19"
+    charm: "cs:xenial/kibana-22"
+    constraints: "mem=3G"
     num_units: 1
     annotations:
       "gui-x": "1626"


### PR DESCRIPTION
The ELK stack is now at v6.  Bump charm revs and add machine constraints.

Fixes #5 

